### PR TITLE
docs: update launch status after public switch and branch protection

### DIFF
--- a/LAUNCH_STATUS_REPORT.md
+++ b/LAUNCH_STATUS_REPORT.md
@@ -17,23 +17,20 @@ This follows `project_launch_workflow_natford.md`.
 - ✅ Milestones seeded (`M0 Foundations`, `M1 MVP`, `M2 Pilot`)
 
 ## 2) Blocked / Pending
-- ⛔ Branch protection blocked on private repo by current GitHub plan (403)
+- ⚠️ Branch protection now applied (PR review + conversation resolution), but required CI status checks are not configured yet.
 - ⛔ Slack channels not yet created/mapped:
   - `#aerial-intel-platform-build`
   - `#aerial-intel-platform-ops`
-- ⛔ Fork-vs-compose legal architecture decision not yet finalized (ADR required).
+- ✅ Fork-vs-compose legal architecture decision drafted in ADR (requires review/approval, not blank anymore).
 - ⛔ No sample dataset benchmark run yet.
 
 ## 3) Exact Next Actions
-1. Decide branch-protection path:
-   - upgrade GitHub plan, or
-   - temporary public repo, or
-   - manual PR discipline while private.
+1. Add CI workflow (`test`, `build`) and then enforce required status checks in branch protection.
 2. Create Slack channels and bot mapping.
-3. Write ADR-001 update: "Compose around ODM vs direct fork".
+3. Review/approve ADR-001 language.
 4. Build technical proof-of-concept pipeline using one controlled demo dataset.
 5. Publish a draft showcase section on natfordplanning.com with clear OSS attribution + limitations.
 
 ## 4) Readiness Snapshot
-- **Setup completeness:** 72%
-- **Operational readiness:** early concept phase, architecture decision pending
+- **Setup completeness:** 82%
+- **Operational readiness:** architecture direction set; waiting on CI + channel mapping + first benchmark run


### PR DESCRIPTION
Updates LAUNCH_STATUS_REPORT to reflect: public repo switch, active branch protection, CI-checks pending, and revised readiness snapshot.