### PR TITLE
docs+ops: add ODM+ comparison, showcase spec, and benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,33 @@ Project slug:
 default branch: main
 
 See project charter and docs folder for current scope and architecture.
+
+## Quickstart (Benchmark Script)
+
+Run ODM against a dataset folder that contains an `images/` directory:
+
+```bash
+./scripts/run_odm_benchmark.sh <dataset_root> <project_name>
+```
+
+Example:
+
+```bash
+./scripts/run_odm_benchmark.sh ./sample-datasets/site-a site-a-baseline
+```
+
+Artifacts are written to:
+
+- `benchmark/<timestamp>/run.log`
+- `benchmark/<timestamp>/summary.json`
+
+Optional overrides:
+
+- `ODM_IMAGE` (default: `opendronemap/odm:latest`)
+- `ODM_ARGS` (default: `--project-path /datasets <project_name>`)
+
+Example override:
+
+```bash
+ODM_IMAGE=opendronemap/odm:3.5.5 ODM_ARGS="--project-path /datasets site-a-baseline --orthophoto-resolution 2" ./scripts/run_odm_benchmark.sh ./sample-datasets/site-a site-a-baseline
+```

--- a/docs/ODM_PLUS_COMPARISON_MATRIX.md
+++ b/docs/ODM_PLUS_COMPARISON_MATRIX.md
@@ -1,0 +1,22 @@
+# ODM+ Comparison Matrix
+
+This matrix compares current open-source ODM options with the proposed Nat Ford ODM+ product direction. It is written for client-facing planning and avoids unreleased claims.
+
+| Capability | ODM CLI | WebODM | NodeODM | Nat Ford ODM+ Differentiator | MVP Phase |
+| --- | --- | --- | --- | --- | --- |
+| Primary interface | Command line on local/remote host | Browser UI for job/project management | HTTP API wrapper around processing node | Opinionated workflow that combines reproducible automation with decision-ready deliverables | Phase 1 |
+| User onboarding | Technical setup; docs-driven | Easier for non-CLI users; still self-host heavy | API-first; developer-centric | Fast-start templates and guided benchmark path for internal/demo use | Phase 1 |
+| Processing orchestration | Manual commands/scripts | Queueing via WebODM server | Programmatic submission to node | Repeatable run protocol with consistent metadata capture and artifacts | Phase 1 |
+| Benchmark reproducibility | Possible but custom to each team | Limited by operator consistency | Possible with disciplined API tooling | Standard benchmark script + protocol docs to compare runs across datasets and hardware | Phase 1 |
+| Output packaging for stakeholders | Raw ODM outputs | Visual project/job views | API access to output files/status | Curated, client-safe output bundles (maps, summaries, QA notes, run metadata) | Phase 2 |
+| Quality assurance workflow | Manual review | Manual review in UI | Must be built in consuming app | Defined QA checklist and acceptance thresholds tied to benchmark outputs | Phase 1 |
+| Commercial readiness posture | Open-source tooling only | Open-source tooling only | Open-source tooling only | Service-oriented delivery model, scoped SLAs/process controls, and client communication templates | Phase 2 |
+| Domain-specific reporting | Not included by default | Not included by default | Not included by default | Verticalized report formats for planning/inspection use cases with clear assumptions/disclaimers | Phase 3 |
+| Deployment flexibility | High, infra-managed by operator | Moderate to high, infra-managed by operator | High for developers | Reference deployment patterns that reduce variance between test, demo, and production | Phase 2 |
+| Governance and traceability | Depends on local practices | Basic job history | Depends on consuming system | Standardized run logs, summary manifests, and versioned protocol documentation | Phase 1 |
+
+## MVP Phase Definitions
+
+- Phase 1: Foundation artifacts for reproducible benchmarks, comparison narrative, and initial demo credibility.
+- Phase 2: Packaging and operational hardening for client pilots.
+- Phase 3: Domain-tailored analytics/reporting extensions.

--- a/docs/SAMPLE_DATASET_BENCHMARK_PROTOCOL.md
+++ b/docs/SAMPLE_DATASET_BENCHMARK_PROTOCOL.md
@@ -1,0 +1,113 @@
+# Sample Dataset Benchmark Protocol
+
+## Objective
+
+Produce reproducible ODM benchmark runs that can be compared across datasets, hardware profiles, and configuration choices.
+
+## Scope
+
+- Baseline engine: ODM Docker image
+- Input: image-only datasets (optional GCP files allowed if explicitly noted)
+- Output: runtime logs, summary manifest, and QA checklist results
+
+## Required Dataset Metadata
+
+Record the following before each run:
+
+- Dataset ID and name
+- Source/owner and usage permission status
+- Capture date
+- Location (generalized if sensitive)
+- Sensor/camera model
+- Image count
+- Total image size (GB)
+- Average GSD estimate (if known)
+- Overlap estimate (front/side, if known)
+- Control data:
+  - GCP present (yes/no)
+  - Coordinate reference details
+
+## Hardware and Environment Record
+
+Capture:
+
+- Host OS and kernel
+- CPU model and core/thread count
+- RAM (GB)
+- GPU model and driver (if used)
+- Docker version
+- ODM image tag/digest
+- Available disk space before run
+
+## Benchmark Configuration
+
+For each run, store:
+
+- Project name
+- Full ODM command arguments
+- Key parameters tracked explicitly:
+  - `--orthophoto-resolution`
+  - `--dem-resolution`
+  - `--feature-quality`
+  - `--pc-quality`
+  - Any fast-orthophoto/split/mesh options
+- Randomness controls/seeding notes (if any step is non-deterministic)
+
+## Runtime Measurement Rules
+
+- Use wall-clock runtime from command start to process exit.
+- Record start/end timestamps in UTC.
+- Record exit code.
+- Capture stdout/stderr to run log without truncation.
+- If run fails, retain all partial logs and mark status as failed.
+
+## Output Artifacts
+
+For each run, publish:
+
+- `run.log`
+- `summary.json` with:
+  - dataset metadata
+  - hardware/environment snapshot
+  - command args
+  - runtime timing
+  - exit status
+  - key output file presence checks
+- Output inventory list (file names + sizes) for major deliverables:
+  - Orthophoto
+  - DEM/DSM
+  - Point cloud
+  - Texturing/mesh (if enabled)
+
+## QA Checks
+
+Minimum QA gate per run:
+
+- Completeness:
+  - Required output files exist.
+- Integrity:
+  - Output files are non-zero size.
+- Geospatial sanity:
+  - CRS metadata present where expected.
+- Visual spot check:
+  - At least 3 sample areas reviewed for obvious artifacts (blur, seam distortion, severe holes).
+- Log health:
+  - No unreviewed fatal errors.
+
+## Comparison Reporting
+
+When comparing runs, report:
+
+- Runtime delta (% and absolute)
+- Output size delta
+- QA pass/fail deltas
+- Material parameter differences
+- Observed tradeoffs (speed vs detail, completeness vs noise)
+
+## Reproducibility Requirements
+
+- Keep dataset immutable during comparison cycle.
+- Pin ODM image version for the test set.
+- Run from clean output directory per attempt.
+- Record any manual interventions explicitly.
+- Treat undocumented parameter changes as invalidating strict comparisons.

--- a/docs/SHOWCASE_PAGE_SPEC.md
+++ b/docs/SHOWCASE_PAGE_SPEC.md
@@ -1,0 +1,90 @@
+# natfordplanning.com ODM+ Showcase Page Spec
+
+## Purpose
+
+Present ODM+ as a credible, practical geospatial processing offer with clear scope, transparent constraints, and an easy lead handoff.
+
+## Audience
+
+- Municipal planning teams
+- Engineering/inspection consultants
+- Drone service operators needing repeatable processing workflows
+
+## Page Structure
+
+1. Hero section
+- Headline: "ODM+ for Reliable Drone Mapping Delivery"
+- Subhead: "OpenDroneMap-based processing workflows with reproducible benchmarks and client-ready outputs."
+- Primary CTA button: "Book a 20-Minute Discovery Call"
+- Secondary CTA button: "Request Benchmark Sample Pack"
+
+2. Problem and outcome section
+- Title: "From Raw Imagery to Decisions, Faster"
+- Three pain points: inconsistent outputs, unclear QA, non-repeatable workflows.
+- Three outcomes: standardized runs, transparent QA checks, clear delivery artifacts.
+
+3. "How ODM+ Works" section
+- Step 1: Intake (dataset and objective review)
+- Step 2: Processing (ODM run using documented config)
+- Step 3: QA + packaging (checklist and output bundle)
+- Step 4: Handoff (summary and next-step recommendations)
+
+4. Capability snapshot section
+- Compact table: baseline OSS capability vs ODM+ process layer
+- Link/anchor to detailed matrix in `docs/ODM_PLUS_COMPARISON_MATRIX.md`
+
+5. Benchmark credibility section
+- Copy: "Runs are documented with dataset metadata, hardware context, command args, timing, and QA checkpoints."
+- CTA: "Download Benchmark Protocol"
+- Link/anchor to `docs/SAMPLE_DATASET_BENCHMARK_PROTOCOL.md`
+
+6. Trust, safety, and license disclosures section
+- Safety notice: "ODM+ outputs support planning/inspection workflows and do not replace licensed professional judgment where required."
+- Data handling notice: "Client data is processed only for agreed scope; retention/deletion terms are defined per engagement."
+- License notice: "Processing pipeline uses OpenDroneMap ecosystem components under their respective open-source licenses."
+- Accuracy notice: "Output quality depends on source imagery quality, overlap, GCP/control quality, and environmental conditions."
+
+7. Lead capture section
+- Form fields:
+  - Name (required)
+  - Work email (required)
+  - Organization (required)
+  - Use case type (dropdown: planning, inspection, other)
+  - Estimated dataset size (optional)
+  - Timeline (dropdown)
+  - Notes (optional)
+- Consent checkbox (required): "I agree to be contacted about ODM+ services."
+- Submit button: "Request ODM+ Consultation"
+
+8. Footer CTA strip
+- Copy: "Need a reality check on your current drone mapping workflow?"
+- Button: "Schedule Discovery Call"
+
+## CTA Copy Library
+
+- Primary hero CTA: "Book a 20-Minute Discovery Call"
+- Secondary hero CTA: "Request Benchmark Sample Pack"
+- Mid-page CTA: "Download Benchmark Protocol"
+- Form submit CTA: "Request ODM+ Consultation"
+- Footer CTA: "Schedule Discovery Call"
+
+## Lead Capture Flow
+
+1. User submits form.
+2. Frontend validates required fields and consent.
+3. Backend stores lead with timestamp, source page, and UTM parameters.
+4. Auto-response email sent within 5 minutes:
+- Subject: "ODM+ request received"
+- Body: expected response window and requested prep items.
+5. Internal routing:
+- New lead notification to sales/ops inbox or CRM webhook.
+- Priority tags by timeline and use case.
+6. SLA target:
+- Human follow-up within 1 business day.
+
+## Compliance and Disclosure Requirements
+
+- Include privacy policy link near form.
+- Include terms link in footer.
+- Display open-source attribution and links to ODM ecosystem repositories/licenses.
+- Do not claim guaranteed accuracy or regulatory certification unless contractually supported.

--- a/scripts/run_odm_benchmark.sh
+++ b/scripts/run_odm_benchmark.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+json_escape() {
+  echo "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+usage() {
+  echo "Usage: $0 <dataset_root> <project_name>"
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is not installed or not in PATH." >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Error: docker daemon is not reachable." >&2
+  exit 1
+fi
+
+DATASET_ROOT="$1"
+PROJECT_NAME="$2"
+
+if [[ ! -d "$DATASET_ROOT" ]]; then
+  echo "Error: dataset_root does not exist: $DATASET_ROOT" >&2
+  exit 1
+fi
+
+if [[ ! -d "$DATASET_ROOT/images" ]]; then
+  echo "Error: expected images folder at $DATASET_ROOT/images" >&2
+  exit 1
+fi
+
+if [[ -z "$(find "$DATASET_ROOT/images" -type f | head -n 1)" ]]; then
+  echo "Error: no image files found in $DATASET_ROOT/images" >&2
+  exit 1
+fi
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="benchmark/$TIMESTAMP"
+RUN_LOG="$RUN_DIR/run.log"
+SUMMARY_JSON="$RUN_DIR/summary.json"
+START_EPOCH="$(date +%s)"
+START_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$RUN_DIR"
+
+ODM_IMAGE="${ODM_IMAGE:-opendronemap/odm:latest}"
+ODM_ARGS="${ODM_ARGS:---project-path /datasets ${PROJECT_NAME}}"
+
+ABS_DATASET_ROOT="$(cd "$DATASET_ROOT" && pwd)"
+IMAGE_COUNT="$(find "$DATASET_ROOT/images" -type f | wc -l | tr -d ' ')"
+DOCKER_VERSION="$(docker --version)"
+HOSTNAME_VALUE="$(hostname)"
+ESC_START_UTC="$(json_escape "$START_UTC")"
+ESC_DATASET_ROOT="$(json_escape "$ABS_DATASET_ROOT")"
+ESC_PROJECT_NAME="$(json_escape "$PROJECT_NAME")"
+ESC_ODM_IMAGE="$(json_escape "$ODM_IMAGE")"
+ESC_ODM_ARGS="$(json_escape "$ODM_ARGS")"
+ESC_DOCKER_VERSION="$(json_escape "$DOCKER_VERSION")"
+ESC_HOSTNAME="$(json_escape "$HOSTNAME_VALUE")"
+
+{
+  echo "timestamp_utc=$START_UTC"
+  echo "dataset_root=$ABS_DATASET_ROOT"
+  echo "project_name=$PROJECT_NAME"
+  echo "odm_image=$ODM_IMAGE"
+  echo "odm_args=$ODM_ARGS"
+  echo "docker_version=$DOCKER_VERSION"
+  echo "host=$HOSTNAME_VALUE"
+  echo "image_count=$IMAGE_COUNT"
+  echo
+  echo "Running ODM benchmark..."
+  echo "Command: docker run --rm -v $ABS_DATASET_ROOT:/datasets $ODM_IMAGE $ODM_ARGS"
+  echo
+} | tee "$RUN_LOG"
+
+set +e
+docker run --rm -v "$ABS_DATASET_ROOT:/datasets" "$ODM_IMAGE" $ODM_ARGS 2>&1 | tee -a "$RUN_LOG"
+RUN_EXIT_CODE="${PIPESTATUS[0]}"
+set -e
+
+END_EPOCH="$(date +%s)"
+END_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+DURATION_SECONDS="$((END_EPOCH - START_EPOCH))"
+
+STATUS="success"
+if [[ "$RUN_EXIT_CODE" -ne 0 ]]; then
+  STATUS="failed"
+fi
+
+{
+  echo
+  echo "run_exit_code=$RUN_EXIT_CODE"
+  echo "status=$STATUS"
+  echo "end_timestamp_utc=$END_UTC"
+  echo "duration_seconds=$DURATION_SECONDS"
+} | tee -a "$RUN_LOG"
+
+cat >"$SUMMARY_JSON" <<EOF
+{
+  "timestamp_utc": "$ESC_START_UTC",
+  "dataset_root": "$ESC_DATASET_ROOT",
+  "project_name": "$ESC_PROJECT_NAME",
+  "odm_image": "$ESC_ODM_IMAGE",
+  "odm_args": "$ESC_ODM_ARGS",
+  "docker_version": "$ESC_DOCKER_VERSION",
+  "host": "$ESC_HOSTNAME",
+  "image_count": $IMAGE_COUNT,
+  "run_exit_code": $RUN_EXIT_CODE,
+  "status": "$STATUS",
+  "end_timestamp_utc": "$END_UTC",
+  "duration_seconds": $DURATION_SECONDS,
+  "run_log": "$RUN_LOG"
+}
+EOF
+
+echo "Benchmark artifacts:"
+echo "  $RUN_LOG"
+echo "  $SUMMARY_JSON"
+
+exit "$RUN_EXIT_CODE"


### PR DESCRIPTION
Adds foundational ODM+ product artifacts:\n- comparison matrix\n- showcase page spec\n- benchmark protocol\n- runnable benchmark script\n- README quickstart update