### PR TITLE
Harden ODM benchmark pipeline and update launch docs

### DIFF
--- a/LAUNCH_STATUS_REPORT.md
+++ b/LAUNCH_STATUS_REPORT.md
@@ -22,21 +22,26 @@ This follows `project_launch_workflow_natford.md`.
   - `docs/SHOWCASE_PAGE_SPEC.md`
   - `docs/SAMPLE_DATASET_BENCHMARK_PROTOCOL.md`
   - `scripts/run_odm_benchmark.sh`
+- ✅ Benchmark pipeline robustness increment shipped:
+  - `scripts/run_odm_benchmark.sh` now includes deterministic preflight mode, disk/docker gates, pinned ODM default image, and output inventory artifacts.
+  - `docs/SAMPLE_DATASET_BENCHMARK_PROTOCOL.md` updated with mandatory preflight and deterministic operator workflow.
+  - `docs/2026-02-25-benchmark-pipeline-hardening.md` added as engineering progress note.
 - ✅ Slack project lanes created/mapped:
   - `#aerial-intel-platform-build`
   - `#aerial-intel-platform-ops`
 
 ## 2) Blocked / Pending
 - ✅ Fork-vs-compose legal architecture decision drafted in ADR (requires review/approval).
-- ⛔ First sample dataset benchmark run not executed yet.
+- ⛔ First sample dataset benchmark run not executed yet (dataset handoff still pending).
 - ⛔ natfordplanning.com showcase page not yet implemented in production.
 
 ## 3) Exact Next Actions
-1. Run first benchmark with `scripts/run_odm_benchmark.sh` on a controlled sample dataset and archive artifacts.
-2. Open implementation issue for showcase page using `docs/SHOWCASE_PAGE_SPEC.md`.
-3. Publish first public comparison snapshot (OSS baseline vs ODM+ process layer) with clear attribution.
+1. Stage first sample dataset in `<dataset_root>/images`, then pass preflight gate:
+   - `./scripts/run_odm_benchmark.sh --preflight-only <dataset_root> <label>`
+2. Execute first benchmark run and archive `preflight.txt`, `run.log`, `output_inventory.tsv`, and `summary.json`.
+3. Open implementation issue for showcase page using `docs/SHOWCASE_PAGE_SPEC.md`.
 4. Review/approve ADR-001 language and lock compliance notes.
 
 ## 4) Readiness Snapshot
-- **Setup completeness:** 90%
-- **Operational readiness:** strong foundation complete; waiting on first benchmark evidence + live showcase implementation
+- **Setup completeness:** 93%
+- **Operational readiness:** robust benchmark pipeline is in place; waiting on first benchmark evidence + live showcase implementation

--- a/LAUNCH_STATUS_REPORT.md
+++ b/LAUNCH_STATUS_REPORT.md
@@ -15,22 +15,28 @@ This follows `project_launch_workflow_natford.md`.
   - `https://github.com/nfredmond/aerial-intel-platform`
 - ✅ Labels seeded (`priority:*`, `type:*`, `status:*`)
 - ✅ Milestones seeded (`M0 Foundations`, `M1 MVP`, `M2 Pilot`)
-
-## 2) Blocked / Pending
-- ⚠️ Branch protection now applied (PR review + conversation resolution), but required CI status checks are not configured yet.
-- ⛔ Slack channels not yet created/mapped:
+- ✅ Branch protection active on `main` with required checks + conversation resolution.
+- ✅ CI workflow active (`test`, `build`) and enforced by branch protection.
+- ✅ Foundational product artifacts shipped and merged:
+  - `docs/ODM_PLUS_COMPARISON_MATRIX.md`
+  - `docs/SHOWCASE_PAGE_SPEC.md`
+  - `docs/SAMPLE_DATASET_BENCHMARK_PROTOCOL.md`
+  - `scripts/run_odm_benchmark.sh`
+- ✅ Slack project lanes created/mapped:
   - `#aerial-intel-platform-build`
   - `#aerial-intel-platform-ops`
-- ✅ Fork-vs-compose legal architecture decision drafted in ADR (requires review/approval, not blank anymore).
-- ⛔ No sample dataset benchmark run yet.
+
+## 2) Blocked / Pending
+- ✅ Fork-vs-compose legal architecture decision drafted in ADR (requires review/approval).
+- ⛔ First sample dataset benchmark run not executed yet.
+- ⛔ natfordplanning.com showcase page not yet implemented in production.
 
 ## 3) Exact Next Actions
-1. Add CI workflow (`test`, `build`) and then enforce required status checks in branch protection.
-2. Create Slack channels and bot mapping.
-3. Review/approve ADR-001 language.
-4. Build technical proof-of-concept pipeline using one controlled demo dataset.
-5. Publish a draft showcase section on natfordplanning.com with clear OSS attribution + limitations.
+1. Run first benchmark with `scripts/run_odm_benchmark.sh` on a controlled sample dataset and archive artifacts.
+2. Open implementation issue for showcase page using `docs/SHOWCASE_PAGE_SPEC.md`.
+3. Publish first public comparison snapshot (OSS baseline vs ODM+ process layer) with clear attribution.
+4. Review/approve ADR-001 language and lock compliance notes.
 
 ## 4) Readiness Snapshot
-- **Setup completeness:** 82%
-- **Operational readiness:** architecture direction set; waiting on CI + channel mapping + first benchmark run
+- **Setup completeness:** 90%
+- **Operational readiness:** strong foundation complete; waiting on first benchmark evidence + live showcase implementation

--- a/README.md
+++ b/README.md
@@ -1,36 +1,54 @@
 # Nat Ford Aerial Intelligence Platform (ODM+)
 
-Project slug: 
+Project slug:
 default branch: main
 
 See project charter and docs folder for current scope and architecture.
 
 ## Quickstart (Benchmark Script)
 
-Run ODM against a dataset folder that contains an `images/` directory:
+Run preflight first, then execute ODM benchmark:
 
 ```bash
-./scripts/run_odm_benchmark.sh <dataset_root> <project_name>
+./scripts/run_odm_benchmark.sh --preflight-only <dataset_root> [benchmark_label]
+./scripts/run_odm_benchmark.sh <dataset_root> [benchmark_label]
+```
+
+Expected dataset layout:
+
+```text
+<dataset_root>/
+  images/
+    IMG_0001.JPG
+    IMG_0002.JPG
+    ...
 ```
 
 Example:
 
 ```bash
+./scripts/run_odm_benchmark.sh --preflight-only ./sample-datasets/site-a site-a-baseline
 ./scripts/run_odm_benchmark.sh ./sample-datasets/site-a site-a-baseline
 ```
 
 Artifacts are written to:
 
-- `benchmark/<timestamp>/run.log`
-- `benchmark/<timestamp>/summary.json`
+- `benchmark/<timestamp>-<label>/preflight.txt`
+- `benchmark/<timestamp>-<label>/run.log`
+- `benchmark/<timestamp>-<label>/output_inventory.tsv`
+- `benchmark/<timestamp>-<label>/summary.json`
 
-Optional overrides:
+Optional environment overrides:
 
-- `ODM_IMAGE` (default: `opendronemap/odm:latest`)
-- `ODM_ARGS` (default: `--project-path /datasets <project_name>`)
+- `ODM_IMAGE` (default: `opendronemap/odm:3.5.5`)
+- `ODM_PROJECT_NAME` (default: basename of `dataset_root`)
+- `ODM_EXTRA_ARGS` (appended in deterministic mode)
+- `ODM_ARGS` (full override, advanced/legacy)
+- `MIN_FREE_GB` (default: `40`)
 
 Example override:
 
 ```bash
-ODM_IMAGE=opendronemap/odm:3.5.5 ODM_ARGS="--project-path /datasets site-a-baseline --orthophoto-resolution 2" ./scripts/run_odm_benchmark.sh ./sample-datasets/site-a site-a-baseline
+ODM_EXTRA_ARGS="--orthophoto-resolution 2 --dem-resolution 5" \
+  ./scripts/run_odm_benchmark.sh ./sample-datasets/site-a site-a-tuned
 ```

--- a/docs/2026-02-25-benchmark-pipeline-hardening.md
+++ b/docs/2026-02-25-benchmark-pipeline-hardening.md
@@ -1,0 +1,38 @@
+# Progress Note — 2026-02-25 — Benchmark Pipeline Hardening
+
+## Summary
+
+Delivered a robustness increment for ODM benchmark execution focused on deterministic operator flow when sample datasets are delayed.
+
+## Shipped in this increment
+
+- Hardened `scripts/run_odm_benchmark.sh` with:
+  - `--preflight-only` mode
+  - dataset contract validation (`images/` + supported file extensions)
+  - Docker daemon availability check
+  - disk headroom gate (`MIN_FREE_GB`, default 40GB)
+  - deterministic default ODM image pin (`opendronemap/odm:3.5.5`)
+  - deterministic argument mode (`ODM_EXTRA_ARGS`) with explicit legacy override mode (`ODM_ARGS`)
+  - richer benchmark artifacts: `preflight.txt`, `output_inventory.tsv`, expanded `summary.json`
+- Updated protocol documentation to include mandatory preflight gate and deterministic execution conventions.
+- Updated README quickstart to enforce preflight-first execution.
+
+## Why this matters
+
+- Removes ambiguous failure modes before expensive ODM runtime.
+- Creates repeatable operator behavior while waiting for sample dataset handoff.
+- Improves comparability of future benchmark runs by pinning defaults and recording preflight context.
+
+## Operator guidance
+
+1. Stage dataset under `<dataset_root>/images`.
+2. Run preflight:
+   - `./scripts/run_odm_benchmark.sh --preflight-only <dataset_root> <label>`
+3. Resolve any preflight failures.
+4. Run benchmark:
+   - `./scripts/run_odm_benchmark.sh <dataset_root> <label>`
+5. Archive `preflight.txt`, `run.log`, `output_inventory.tsv`, and `summary.json`.
+
+## Current blocker state
+
+- No benchmark evidence yet because sample dataset is still pending.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Hardened benchmark execution pipeline with deterministic preflight mode in `scripts/run_odm_benchmark.sh`.
+- Added benchmark artifact inventory output (`output_inventory.tsv`) and expanded `summary.json` metadata.
+- Updated benchmark protocol + README to enforce preflight-first operator workflow.
+- Added progress note: `docs/2026-02-25-benchmark-pipeline-hardening.md`.
 - Initialized project scaffold.

--- a/scripts/run_odm_benchmark.sh
+++ b/scripts/run_odm_benchmark.sh
@@ -1,89 +1,234 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME="$(basename "$0")"
+DEFAULT_ODM_IMAGE="opendronemap/odm:3.5.5"
+DEFAULT_MIN_FREE_GB=40
 
 json_escape() {
   echo "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
 }
 
-usage() {
-  echo "Usage: $0 <dataset_root> <project_name>"
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
 }
 
-if [[ $# -ne 2 ]]; then
+usage() {
+  cat <<EOF
+Usage:
+  $SCRIPT_NAME [--preflight-only] <dataset_root> [benchmark_label]
+
+Arguments:
+  dataset_root      Path to dataset directory containing images/.
+  benchmark_label   Optional label for benchmark artifact folder.
+
+Options:
+  --preflight-only  Run validation checks and write preflight artifacts only.
+  -h, --help        Show this help message.
+
+Environment:
+  ODM_IMAGE         Docker image tag to run (default: ${DEFAULT_ODM_IMAGE})
+  ODM_PROJECT_NAME  ODM project folder name under /datasets (default: basename(dataset_root))
+  ODM_EXTRA_ARGS    Extra ODM CLI arguments appended in deterministic mode.
+  ODM_ARGS          Full ODM argument override (advanced/legacy; bypasses deterministic defaults).
+  MIN_FREE_GB       Minimum free disk space required on dataset volume (default: ${DEFAULT_MIN_FREE_GB})
+
+Examples:
+  $SCRIPT_NAME ./sample-datasets/site-a
+  $SCRIPT_NAME --preflight-only ./sample-datasets/site-a site-a-baseline
+  ODM_EXTRA_ARGS="--orthophoto-resolution 2 --dem-resolution 5" \\
+    $SCRIPT_NAME ./sample-datasets/site-a site-a-tuned
+EOF
+}
+
+print_dataset_contract() {
+  local dataset_root="$1"
+  cat <<EOF
+Dataset contract:
+  <dataset_root>/
+    images/
+      IMG_0001.JPG
+      IMG_0002.JPG
+      ...
+
+Expected image extensions: jpg, jpeg, tif, tiff, png
+
+If sample data has not arrived yet, prepare an empty folder now so preflight is deterministic later:
+  mkdir -p "${dataset_root}/images"
+
+Then add source imagery and rerun:
+  $SCRIPT_NAME --preflight-only "${dataset_root}" <benchmark_label>
+  $SCRIPT_NAME "${dataset_root}" <benchmark_label>
+EOF
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command not found in PATH: $cmd" >&2
+    exit 2
+  fi
+}
+
+image_count_in_dir() {
+  local images_dir="$1"
+  find "$images_dir" -type f \( \
+    -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.tif' -o -iname '*.tiff' -o -iname '*.png' \
+  \) | wc -l | tr -d ' '
+}
+
+PRECHECK_ONLY=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --preflight-only)
+      PRECHECK_ONLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
   usage
   exit 1
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Error: docker is not installed or not in PATH." >&2
-  exit 1
-fi
-
-if ! docker info >/dev/null 2>&1; then
-  echo "Error: docker daemon is not reachable." >&2
-  exit 1
-fi
-
 DATASET_ROOT="$1"
-PROJECT_NAME="$2"
+BENCHMARK_LABEL="${2:-$(basename "$DATASET_ROOT")}"
+ODM_IMAGE="${ODM_IMAGE:-$DEFAULT_ODM_IMAGE}"
+MIN_FREE_GB="${MIN_FREE_GB:-$DEFAULT_MIN_FREE_GB}"
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_SLUG="$(slugify "$BENCHMARK_LABEL")"
+if [[ -z "$RUN_SLUG" ]]; then
+  RUN_SLUG="benchmark"
+fi
+RUN_DIR="benchmark/${TIMESTAMP}-${RUN_SLUG}"
+RUN_LOG="$RUN_DIR/run.log"
+SUMMARY_JSON="$RUN_DIR/summary.json"
+PRECHECK_FILE="$RUN_DIR/preflight.txt"
+OUTPUT_INVENTORY="$RUN_DIR/output_inventory.tsv"
 
 if [[ ! -d "$DATASET_ROOT" ]]; then
   echo "Error: dataset_root does not exist: $DATASET_ROOT" >&2
-  exit 1
+  print_dataset_contract "$DATASET_ROOT" >&2
+  exit 2
 fi
 
-if [[ ! -d "$DATASET_ROOT/images" ]]; then
-  echo "Error: expected images folder at $DATASET_ROOT/images" >&2
-  exit 1
+ABS_DATASET_ROOT="$(cd "$DATASET_ROOT" && pwd)"
+DATASET_NAME="$(basename "$ABS_DATASET_ROOT")"
+DATASET_PARENT="$(dirname "$ABS_DATASET_ROOT")"
+ODM_PROJECT_NAME="${ODM_PROJECT_NAME:-$DATASET_NAME}"
+ODM_PROJECT_HOST_PATH="$DATASET_PARENT/$ODM_PROJECT_NAME"
+IMAGES_PATH="$ODM_PROJECT_HOST_PATH/images"
+
+if [[ -n "${ODM_ARGS:-}" ]]; then
+  ODM_ARGS_MODE="override"
+  # shellcheck disable=SC2206
+  ODM_ARGS_ARRAY=( ${ODM_ARGS} )
+else
+  ODM_ARGS_MODE="deterministic"
+  ODM_ARGS_ARRAY=(--project-path /datasets "$ODM_PROJECT_NAME")
+  if [[ -n "${ODM_EXTRA_ARGS:-}" ]]; then
+    # shellcheck disable=SC2206
+    EXTRA_ARGS_ARRAY=( ${ODM_EXTRA_ARGS} )
+    ODM_ARGS_ARRAY+=("${EXTRA_ARGS_ARRAY[@]}")
+  fi
 fi
 
-if [[ -z "$(find "$DATASET_ROOT/images" -type f | head -n 1)" ]]; then
-  echo "Error: no image files found in $DATASET_ROOT/images" >&2
-  exit 1
+if [[ ! -d "$IMAGES_PATH" ]]; then
+  echo "Error: expected images folder at: $IMAGES_PATH" >&2
+  echo "Hint: dataset_root should point at a directory where 'images/' exists, or set ODM_PROJECT_NAME to the dataset folder name." >&2
+  print_dataset_contract "$ABS_DATASET_ROOT" >&2
+  exit 2
 fi
 
-TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
-RUN_DIR="benchmark/$TIMESTAMP"
-RUN_LOG="$RUN_DIR/run.log"
-SUMMARY_JSON="$RUN_DIR/summary.json"
+IMAGE_COUNT="$(image_count_in_dir "$IMAGES_PATH")"
+if [[ "$IMAGE_COUNT" -eq 0 ]]; then
+  echo "Error: no supported image files found in $IMAGES_PATH" >&2
+  echo "Supported extensions: jpg, jpeg, tif, tiff, png" >&2
+  print_dataset_contract "$ABS_DATASET_ROOT" >&2
+  exit 2
+fi
+
+require_command docker
+if ! docker info >/dev/null 2>&1; then
+  echo "Error: docker daemon is not reachable." >&2
+  exit 2
+fi
+
+FREE_KB="$(df -Pk "$DATASET_PARENT" | awk 'NR==2 {print $4}')"
+FREE_GB="$((FREE_KB / 1024 / 1024))"
+if [[ "$FREE_GB" -lt "$MIN_FREE_GB" ]]; then
+  echo "Error: only ${FREE_GB}GB free on dataset volume; require at least ${MIN_FREE_GB}GB." >&2
+  echo "Adjust MIN_FREE_GB if this threshold is too strict for your benchmark profile." >&2
+  exit 2
+fi
+
+DOCKER_VERSION="$(docker --version)"
+HOSTNAME_VALUE="$(hostname)"
 START_EPOCH="$(date +%s)"
 START_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+ODMCMD=(docker run --rm -v "${DATASET_PARENT}:/datasets" "$ODM_IMAGE" "${ODM_ARGS_ARRAY[@]}")
+COMMAND_STRING="$(printf '%q ' "${ODMCMD[@]}")"
+ODM_ARGS_HUMAN="$(printf '%s ' "${ODM_ARGS_ARRAY[@]}")"
+ODM_ARGS_HUMAN="${ODM_ARGS_HUMAN% }"
+
 mkdir -p "$RUN_DIR"
-
-ODM_IMAGE="${ODM_IMAGE:-opendronemap/odm:latest}"
-ODM_ARGS="${ODM_ARGS:---project-path /datasets ${PROJECT_NAME}}"
-
-ABS_DATASET_ROOT="$(cd "$DATASET_ROOT" && pwd)"
-IMAGE_COUNT="$(find "$DATASET_ROOT/images" -type f | wc -l | tr -d ' ')"
-DOCKER_VERSION="$(docker --version)"
-HOSTNAME_VALUE="$(hostname)"
-ESC_START_UTC="$(json_escape "$START_UTC")"
-ESC_DATASET_ROOT="$(json_escape "$ABS_DATASET_ROOT")"
-ESC_PROJECT_NAME="$(json_escape "$PROJECT_NAME")"
-ESC_ODM_IMAGE="$(json_escape "$ODM_IMAGE")"
-ESC_ODM_ARGS="$(json_escape "$ODM_ARGS")"
-ESC_DOCKER_VERSION="$(json_escape "$DOCKER_VERSION")"
-ESC_HOSTNAME="$(json_escape "$HOSTNAME_VALUE")"
 
 {
   echo "timestamp_utc=$START_UTC"
   echo "dataset_root=$ABS_DATASET_ROOT"
-  echo "project_name=$PROJECT_NAME"
+  echo "dataset_parent=$DATASET_PARENT"
+  echo "dataset_name=$DATASET_NAME"
+  echo "benchmark_label=$BENCHMARK_LABEL"
+  echo "odm_project_name=$ODM_PROJECT_NAME"
+  echo "images_path=$IMAGES_PATH"
+  echo "image_count=$IMAGE_COUNT"
+  echo "odm_args_mode=$ODM_ARGS_MODE"
   echo "odm_image=$ODM_IMAGE"
-  echo "odm_args=$ODM_ARGS"
+  echo "odm_args=$ODM_ARGS_HUMAN"
   echo "docker_version=$DOCKER_VERSION"
   echo "host=$HOSTNAME_VALUE"
-  echo "image_count=$IMAGE_COUNT"
+  echo "free_disk_gb=$FREE_GB"
+  echo "min_free_gb=$MIN_FREE_GB"
+  echo "preflight_status=passed"
+  echo "command=$COMMAND_STRING"
+} | tee "$PRECHECK_FILE" >/dev/null
+
+if [[ "$PRECHECK_ONLY" -eq 1 ]]; then
+  echo "Preflight passed. Artifacts:"
+  echo "  $PRECHECK_FILE"
+  exit 0
+fi
+
+{
+  cat "$PRECHECK_FILE"
   echo
   echo "Running ODM benchmark..."
-  echo "Command: docker run --rm -v $ABS_DATASET_ROOT:/datasets $ODM_IMAGE $ODM_ARGS"
   echo
-} | tee "$RUN_LOG"
+} | tee "$RUN_LOG" >/dev/null
 
 set +e
-docker run --rm -v "$ABS_DATASET_ROOT:/datasets" "$ODM_IMAGE" $ODM_ARGS 2>&1 | tee -a "$RUN_LOG"
+"${ODMCMD[@]}" 2>&1 | tee -a "$RUN_LOG"
 RUN_EXIT_CODE="${PIPESTATUS[0]}"
 set -e
 
@@ -96,34 +241,93 @@ if [[ "$RUN_EXIT_CODE" -ne 0 ]]; then
   STATUS="failed"
 fi
 
+PROJECT_OUTPUT_ROOT="$ODM_PROJECT_HOST_PATH"
+EXPECTED_OUTPUTS=(
+  "odm_orthophoto/odm_orthophoto.tif"
+  "odm_dem/dsm.tif"
+  "odm_dem/dtm.tif"
+  "odm_georeferencing/odm_georeferenced_model.laz"
+  "odm_texturing/odm_textured_model.obj"
+)
+
+KEY_OUTPUTS_PRESENT=0
+{
+  echo -e "status\trelative_path\tbytes"
+  for rel_path in "${EXPECTED_OUTPUTS[@]}"; do
+    abs_path="$PROJECT_OUTPUT_ROOT/$rel_path"
+    if [[ -s "$abs_path" ]]; then
+      file_status="present"
+      bytes="$(stat -c%s "$abs_path")"
+      KEY_OUTPUTS_PRESENT="$((KEY_OUTPUTS_PRESENT + 1))"
+    elif [[ -e "$abs_path" ]]; then
+      file_status="empty"
+      bytes="$(stat -c%s "$abs_path" 2>/dev/null || echo 0)"
+    else
+      file_status="missing"
+      bytes=0
+    fi
+    echo -e "${file_status}\t${rel_path}\t${bytes}"
+  done
+} >"$OUTPUT_INVENTORY"
+
 {
   echo
   echo "run_exit_code=$RUN_EXIT_CODE"
   echo "status=$STATUS"
   echo "end_timestamp_utc=$END_UTC"
   echo "duration_seconds=$DURATION_SECONDS"
-} | tee -a "$RUN_LOG"
+  echo "key_outputs_present=$KEY_OUTPUTS_PRESENT"
+  echo "key_outputs_expected=${#EXPECTED_OUTPUTS[@]}"
+} | tee -a "$RUN_LOG" >/dev/null
+
+ESC_START_UTC="$(json_escape "$START_UTC")"
+ESC_END_UTC="$(json_escape "$END_UTC")"
+ESC_DATASET_ROOT="$(json_escape "$ABS_DATASET_ROOT")"
+ESC_DATASET_PARENT="$(json_escape "$DATASET_PARENT")"
+ESC_DATASET_NAME="$(json_escape "$DATASET_NAME")"
+ESC_BENCHMARK_LABEL="$(json_escape "$BENCHMARK_LABEL")"
+ESC_ODM_PROJECT_NAME="$(json_escape "$ODM_PROJECT_NAME")"
+ESC_ODM_IMAGE="$(json_escape "$ODM_IMAGE")"
+ESC_ODM_ARGS_MODE="$(json_escape "$ODM_ARGS_MODE")"
+ESC_ODM_ARGS="$(json_escape "$ODM_ARGS_HUMAN")"
+ESC_DOCKER_VERSION="$(json_escape "$DOCKER_VERSION")"
+ESC_HOSTNAME="$(json_escape "$HOSTNAME_VALUE")"
+ESC_RUN_LOG="$(json_escape "$RUN_LOG")"
+ESC_PRECHECK_FILE="$(json_escape "$PRECHECK_FILE")"
+ESC_OUTPUT_INVENTORY="$(json_escape "$OUTPUT_INVENTORY")"
 
 cat >"$SUMMARY_JSON" <<EOF
 {
   "timestamp_utc": "$ESC_START_UTC",
+  "end_timestamp_utc": "$ESC_END_UTC",
+  "status": "$STATUS",
+  "run_exit_code": $RUN_EXIT_CODE,
+  "duration_seconds": $DURATION_SECONDS,
   "dataset_root": "$ESC_DATASET_ROOT",
-  "project_name": "$ESC_PROJECT_NAME",
+  "dataset_parent": "$ESC_DATASET_PARENT",
+  "dataset_name": "$ESC_DATASET_NAME",
+  "benchmark_label": "$ESC_BENCHMARK_LABEL",
+  "odm_project_name": "$ESC_ODM_PROJECT_NAME",
+  "image_count": $IMAGE_COUNT,
   "odm_image": "$ESC_ODM_IMAGE",
+  "odm_args_mode": "$ESC_ODM_ARGS_MODE",
   "odm_args": "$ESC_ODM_ARGS",
   "docker_version": "$ESC_DOCKER_VERSION",
   "host": "$ESC_HOSTNAME",
-  "image_count": $IMAGE_COUNT,
-  "run_exit_code": $RUN_EXIT_CODE,
-  "status": "$STATUS",
-  "end_timestamp_utc": "$END_UTC",
-  "duration_seconds": $DURATION_SECONDS,
-  "run_log": "$RUN_LOG"
+  "free_disk_gb": $FREE_GB,
+  "min_free_gb": $MIN_FREE_GB,
+  "key_outputs_present": $KEY_OUTPUTS_PRESENT,
+  "key_outputs_expected": ${#EXPECTED_OUTPUTS[@]},
+  "preflight_file": "$ESC_PRECHECK_FILE",
+  "output_inventory": "$ESC_OUTPUT_INVENTORY",
+  "run_log": "$ESC_RUN_LOG"
 }
 EOF
 
 echo "Benchmark artifacts:"
+echo "  $PRECHECK_FILE"
 echo "  $RUN_LOG"
+echo "  $OUTPUT_INVENTORY"
 echo "  $SUMMARY_JSON"
 
 exit "$RUN_EXIT_CODE"


### PR DESCRIPTION
## Summary
- harden `run_odm_benchmark.sh` with deterministic preflight checks and operator safeguards
- update benchmark protocol and README with preflight-first flow
- add dated progress note and changelog entries
- refresh launch status with revised readiness + next actions

## Why
This moves the project from setup-only to execution-ready benchmark operations once sample imagery is staged.

## Validation
- script-level preflight path implemented (`--preflight-only`)
- artifacts documented: `preflight.txt`, `run.log`, `output_inventory.tsv`, `summary.json`

## Blocker
- first full benchmark run is still blocked on dataset handoff (`<dataset_root>/images`).
