### PR TITLE
[codex] add production readiness gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,46 @@ jobs:
           name: playwright-report
           path: web/playwright-report/
           retention-days: 14
+
+  web-auth-smoke:
+    name: web-auth-smoke
+    runs-on: ubuntu-latest
+    needs: [web-quality]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.AERIAL_E2E_AUTH_SMOKE_ENABLED == '1'
+    defaults:
+      run:
+        working-directory: web
+    env:
+      AERIAL_E2E_AUTH_SMOKE: "1"
+      AERIAL_E2E_BASE_URL: ${{ vars.AERIAL_E2E_BASE_URL }}
+      AERIAL_E2E_SKIP_SERVER: "1"
+      AERIAL_E2E_OWNER_EMAIL: ${{ vars.AERIAL_E2E_OWNER_EMAIL }}
+      AERIAL_E2E_OWNER_USER_ID: ${{ vars.AERIAL_E2E_OWNER_USER_ID }}
+      AERIAL_E2E_ORG_ID: ${{ vars.AERIAL_E2E_ORG_ID }}
+      AERIAL_E2E_RASTER_ARTIFACT_ID: ${{ vars.AERIAL_E2E_RASTER_ARTIFACT_ID }}
+      AERIAL_E2E_SECOND_ARTIFACT_ID: ${{ vars.AERIAL_E2E_SECOND_ARTIFACT_ID }}
+      AERIAL_E2E_SYNTHETIC_JOB_ID: ${{ vars.AERIAL_E2E_SYNTHETIC_JOB_ID }}
+      AERIAL_E2E_EXPECT_RASTER: ${{ vars.AERIAL_E2E_EXPECT_RASTER }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.AERIAL_E2E_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.AERIAL_E2E_SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.AERIAL_E2E_SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run authenticated operational smoke
+        run: npm run test:e2e -- authenticated-ops.spec.ts
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: authenticated-smoke-playwright-report
+          path: web/playwright-report/
+          retention-days: 14

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4,6 +4,19 @@
 - Alert routing
 - On-call/escalation expectations
 
+## Release gates
+
+Use `docs/RELEASE_CHECKLIST.md` before production promotion. At minimum:
+
+```bash
+AERIAL_RELEASE_TARGET=production scripts/check_release_readiness.sh
+AERIAL_TITILER_URL=https://titiler.example.com scripts/smoke_titiler.sh
+```
+
+Production raster delivery requires a controlled TiTiler service. The deployable
+container and Cloud Run example live in `infra/titiler/`; `https://titiler.xyz`
+is Preview-only evidence and must not be used as a production claim.
+
 ## Managed processing dispatch handoff (current truthful v1 lane)
 
 Use this when a mission has a `managed-processing-v1` job and operator intake review is complete.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,57 @@
+# Release checklist
+
+Use this checklist before promoting Aerial Operations OS to production.
+
+## Database
+
+- All migrations in `supabase/migrations` are applied to the target project.
+- `supabase migration list --linked --workdir supabase` has no unexpected drift.
+- RLS smoke confirms active members can read tenant rows and suspended members cannot.
+- Seed/demo rows are not required for production operation.
+
+## Environment
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `CRON_SECRET`
+- `AERIAL_TITILER_URL`
+- `AERIAL_COPILOT_ENABLED`
+- `AERIAL_COPILOT_DEFAULT_CAP_TENTH_CENTS`
+- `AI_GATEWAY_API_KEY` or Vercel OIDC when copilot is enabled
+
+Run:
+
+```bash
+AERIAL_RELEASE_TARGET=production scripts/check_release_readiness.sh
+```
+
+Production must not use `https://titiler.xyz` or any localhost TiTiler URL.
+
+## Raster
+
+- Controlled TiTiler service is deployed outside localhost.
+- `scripts/smoke_titiler.sh` passes against the controlled service URL.
+- Vercel production `AERIAL_TITILER_URL` points at the controlled service.
+- A signed-in artifact page loads at least one `200` TiTiler tile.
+
+## Authenticated smoke
+
+- Dedicated test Supabase project exists.
+- GitHub Actions variables/secrets from `docs/ops/test-supabase-project.md` are set.
+- `web-auth-smoke` is enabled only after fixtures are stable.
+- Latest authenticated smoke passed against the production candidate URL.
+
+## Copilot
+
+- Org-level copilot enablement is intentional.
+- Monthly cap is set for the org.
+- `/admin/copilot` shows quota, recent events, and CSV export.
+- Generated text still renders per-sentence `[fact:*]` citations.
+
+## Rollback
+
+- Last known-good Vercel deployment URL is recorded.
+- Supabase migration rollback plan is documented for any new migration.
+- TiTiler previous service revision is available or the CDN origin can be
+  pointed back to the last known-good service.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@
 - Phase 0 foundations — **complete**.
 - Phase 1 mission-control shell — **complete**, now decomposed around shared UI primitives.
 - Phase 2 ingest / preflight / processing — **largely complete**; NodeODM-direct dispatch added this pass alongside the existing webhook adapter.
-- Phase 3 viewing / delivery / collaboration — **near-complete (delivery pillar honest)**: MapLibre-backed planning + coverage maps shipped; install-bundle export shipped; mission-version snapshot + promote shipped; side-by-side version diff shipped; signed-share artifact links shipped (`/s/[token]`); read-only admin console shipped (`/admin`); Playwright public-showcase smoke shipped; authenticated ops smoke is now opt-in; copy-to-storage for real NodeODM outputs shipped (W1-A); artifact comments + approvals shipped (W1-C); TiTiler-backed raster viewer shipped and Preview-smoked via a temporary public TiTiler endpoint. A controlled Nat Ford TiTiler service is still pending before production claim.
+- Phase 3 viewing / delivery / collaboration — **near-complete (delivery pillar honest)**: MapLibre-backed planning + coverage maps shipped; install-bundle export shipped; mission-version snapshot + promote shipped; side-by-side version diff shipped; signed-share artifact links shipped (`/s/[token]`); read-only admin console shipped (`/admin`); Playwright public-showcase smoke shipped; authenticated ops smoke is now opt-in; copy-to-storage for real NodeODM outputs shipped (W1-A); artifact comments + approvals shipped (W1-C); TiTiler-backed raster viewer shipped and Preview-smoked via a temporary public TiTiler endpoint. Controlled TiTiler deployment artifacts, smoke script, and release gate are now in-repo; the external Nat Ford service still must be deployed before production claim.
 - Phase 4 AI / domain modules — **in progress (Wave 2 copilot landing)**: Aerial Copilot framework + mission-brief (W2-C1) + processing-QA (W2-C2) + data-cleaning scout (W2-C3) + admin support assistant + artifact report-summary generator shipped, default-off per org, grounded via citation-gated output; org-scoped copilot audit events now record attempts, refusals, failures, spend, and sentence-drop counts in the admin dashboard with CSV export for review packets. Processing-QA has live Preview verification through Vercel AI Gateway and uses a bounded Haiku call for the internal diagnostic path.
 - Phase 5 enterprise / ecosystem — **not started**.
 
@@ -47,7 +47,7 @@ Goal: turn the shell into a real operational pipeline.
 Goal: provide WebODM-grade output review with stronger delivery UX.
 
 ### In scope
-- TiTiler-backed COG raster delivery (shipped — W1-B — wired behind `AERIAL_TITILER_URL`; Preview-smoked via `https://titiler.xyz`; controlled Nat Ford TiTiler service pending)
+- TiTiler-backed COG raster delivery (shipped — W1-B — wired behind `AERIAL_TITILER_URL`; Preview-smoked via `https://titiler.xyz`; controlled service deployment artifacts live in `infra/titiler`; external Nat Ford TiTiler service pending)
 - orthomosaic/DSM viewing (shipped — `/artifacts/[artifactId]` renders a MapLibre raster overlay for ready COGs)
 - share pages and export bundles (share pages shipped at `/s/[token]`; export bundles shipped via install-bundle route)
 - comments, approvals, and activity feed depth (activity feed shipped; comments/approvals shipped — W1-C)

--- a/docs/ops/2026-04-20-production-readiness-gates.md
+++ b/docs/ops/2026-04-20-production-readiness-gates.md
@@ -1,0 +1,43 @@
+# Production readiness gates - 2026-04-20
+
+This slice follows the merge of PR #58. It does not claim that production
+raster delivery is live. It moves the remaining production gates into executable
+repo artifacts.
+
+## What shipped
+
+- Controlled TiTiler service artifacts in `infra/titiler/`.
+- `scripts/smoke_titiler.sh` for tilejson and PNG tile smoke checks.
+- `scripts/check_release_readiness.sh` for required env and production TiTiler
+  guardrails.
+- `docs/RELEASE_CHECKLIST.md` for production promotion.
+- `docs/ops/test-supabase-project.md` for the dedicated Supabase E2E project.
+- Optional `web-auth-smoke` GitHub Actions job gated by
+  `AERIAL_E2E_AUTH_SMOKE_ENABLED=1`.
+
+## Validation
+
+From the repository root:
+
+- `bash -n scripts/smoke_titiler.sh scripts/check_release_readiness.sh` - pass.
+- `docker compose -f infra/titiler/docker-compose.yml config` - pass.
+- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service AERIAL_TITILER_URL=https://titiler.example.com AERIAL_RELEASE_TARGET=production scripts/check_release_readiness.sh` - pass.
+- Same readiness command with `AERIAL_TITILER_URL=https://titiler.xyz` and `AERIAL_RELEASE_TARGET=production` - fails as expected.
+- `AERIAL_TITILER_URL=https://titiler.xyz scripts/smoke_titiler.sh` - pass, script validation only against public demo endpoint.
+
+From `web/`:
+
+- `npm ci` - pass.
+- `npm run lint -- --quiet` - pass.
+- `npm run test` - pass, 65 files / 414 tests.
+- `npm run build` - pass.
+- `npm run test:e2e` - pass, 2 public tests and 1 skipped authenticated smoke.
+
+## Remaining external work
+
+- Deploy the controlled TiTiler container to Nat Ford infrastructure.
+- Configure `AERIAL_TITILER_URL` in Vercel Preview and production to the
+  controlled service URL.
+- Create the dedicated Supabase E2E project and set GitHub Actions variables
+  and secrets from `docs/ops/test-supabase-project.md`.
+- Enable `AERIAL_E2E_AUTH_SMOKE_ENABLED=1` only after those fixtures are stable.

--- a/docs/ops/test-supabase-project.md
+++ b/docs/ops/test-supabase-project.md
@@ -1,0 +1,74 @@
+# Dedicated Supabase E2E project
+
+The authenticated Playwright smoke should run against a dedicated test Supabase
+project, not the shared dev project and not production.
+
+## Project requirements
+
+- Separate Supabase project, for example `aerial-ops-e2e`.
+- All migrations in `supabase/migrations` applied.
+- Seeded Nat Ford test org, owner membership, active entitlement, two ready
+  artifacts, and the synthetic failed job.
+- Storage bucket/object fixtures for the raster artifact if
+  `AERIAL_E2E_EXPECT_RASTER=1`.
+- Copilot enabled only if the target Preview has AI Gateway credentials.
+
+## Bootstrap checklist
+
+1. Create the project in Supabase.
+2. Link the local Supabase CLI to that project.
+3. Apply migrations:
+
+   ```bash
+   supabase db push --workdir supabase
+   ```
+
+4. Apply seed data:
+
+   ```bash
+   SUPABASE_URL=https://PROJECT_REF.supabase.co \
+   SUPABASE_SERVICE_ROLE_KEY=... \
+     node scripts/seed_aerial_ops_workspace.mjs --org-slug nat-ford-drone-lab
+
+   supabase db query --linked --workdir supabase \
+     --file seed/2026-04-19-synthetic-failed-job.sql
+   ```
+
+5. Create or confirm the owner auth user:
+
+   ```text
+   test.drone.owner@natfordplanning.test
+   ```
+
+6. Confirm these fixture ids and store them as repository variables:
+
+   - `AERIAL_E2E_BASE_URL`
+   - `AERIAL_E2E_OWNER_EMAIL`
+   - `AERIAL_E2E_OWNER_USER_ID`
+   - `AERIAL_E2E_ORG_ID`
+   - `AERIAL_E2E_RASTER_ARTIFACT_ID`
+   - `AERIAL_E2E_SECOND_ARTIFACT_ID`
+   - `AERIAL_E2E_SYNTHETIC_JOB_ID`
+   - `AERIAL_E2E_EXPECT_RASTER`
+
+7. Store these as repository secrets:
+
+   - `AERIAL_E2E_SUPABASE_URL`
+   - `AERIAL_E2E_SUPABASE_ANON_KEY`
+   - `AERIAL_E2E_SUPABASE_SERVICE_ROLE_KEY`
+
+8. Set repository variable `AERIAL_E2E_AUTH_SMOKE_ENABLED=1` only after the
+   test project and Preview URL are stable.
+
+## CI behavior
+
+The `web-auth-smoke` GitHub Actions job is gated behind:
+
+```text
+github.event_name == 'push'
+github.ref == 'refs/heads/main'
+vars.AERIAL_E2E_AUTH_SMOKE_ENABLED == '1'
+```
+
+This keeps PR CI fast and prevents accidental live-dev/prod fixture use. If the
+variable is unset, the authenticated smoke does not run.

--- a/docs/ops/titiler-setup.md
+++ b/docs/ops/titiler-setup.md
@@ -87,6 +87,22 @@ services:
       MOSAIC_ENDPOINT_ENABLED: "FALSE"
 ```
 
+## Controlled service artifacts
+
+The deployable service shape now lives in `infra/titiler/`:
+
+- `Dockerfile` wraps the official TiTiler image with the expected port and
+  disabled mosaic endpoint.
+- `docker-compose.yml` runs the same shape locally.
+- `cloud-run.service.yaml.example` captures the Cloud Run container settings,
+  resource floor, and CORS envs to fill for a Nat Ford deployment.
+
+Smoke any controlled endpoint before wiring the app to it:
+
+```bash
+AERIAL_TITILER_URL=https://titiler.example.com scripts/smoke_titiler.sh
+```
+
 ## Production deployment notes
 
 - Host TiTiler on its own fly.io / ECS / Cloud Run service. Do not co-locate
@@ -98,6 +114,9 @@ services:
   reloading the artifact page after the TTL expires get a new URL automatically.
   Nothing in TiTiler needs Supabase credentials.
 - Lock `CORS_ORIGINS` to the deployed Next.js origin + any preview domains.
+- Before production promotion, run
+  `AERIAL_RELEASE_TARGET=production scripts/check_release_readiness.sh` and
+  confirm it does not reject the configured TiTiler URL.
 
 ## Verification
 

--- a/infra/titiler/Dockerfile
+++ b/infra/titiler/Dockerfile
@@ -1,0 +1,10 @@
+ARG TITILER_IMAGE=ghcr.io/developmentseed/titiler:latest
+FROM ${TITILER_IMAGE}
+
+ENV PORT=8080
+ENV HOST=0.0.0.0
+ENV MOSAIC_ENDPOINT_ENABLED=FALSE
+
+EXPOSE 8080
+
+CMD ["uvicorn", "titiler.application.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/infra/titiler/README.md
+++ b/infra/titiler/README.md
@@ -1,0 +1,62 @@
+# Controlled TiTiler service
+
+This directory contains the deployable container shape for the controlled raster
+delivery plane. It replaces temporary Preview use of `https://titiler.xyz` with
+a Nat Ford owned TiTiler endpoint.
+
+The app only needs one environment variable:
+
+```bash
+AERIAL_TITILER_URL=https://titiler.example.com
+```
+
+## Local container
+
+```bash
+cd infra/titiler
+docker compose up --build
+```
+
+Then smoke it:
+
+```bash
+AERIAL_TITILER_URL=http://localhost:8080 ../../scripts/smoke_titiler.sh
+```
+
+## Cloud Run shape
+
+`cloud-run.service.yaml.example` is intentionally an example because the final
+project id, region, artifact registry path, and CORS origins are environment
+specific.
+
+Minimal deployment flow:
+
+```bash
+gcloud artifacts repositories create aerial \
+  --repository-format=docker \
+  --location=REGION
+
+gcloud builds submit infra/titiler \
+  --tag REGION-docker.pkg.dev/PROJECT/aerial/titiler:TAG
+
+cp infra/titiler/cloud-run.service.yaml.example /tmp/aerial-titiler.yaml
+# edit image + CORS_ORIGINS in /tmp/aerial-titiler.yaml
+gcloud run services replace /tmp/aerial-titiler.yaml --region REGION
+gcloud run services add-iam-policy-binding aerial-titiler \
+  --region REGION \
+  --member=allUsers \
+  --role=roles/run.invoker
+```
+
+Run `scripts/smoke_titiler.sh` against the Cloud Run URL before setting
+`AERIAL_TITILER_URL` in Vercel.
+
+## Production requirements
+
+- Use a Nat Ford controlled domain, for example `https://titiler.natfordplanning.com`.
+- Restrict `CORS_ORIGINS` to the production app origin and Preview origin pattern.
+- Put Cloudflare, Cloud CDN, or another cache in front before heavy customer use.
+- Pin `TITILER_IMAGE` to a tested digest or tag before production promotion.
+- Keep TiTiler independent from NodeODM; raster serving is latency-sensitive while
+  ODM processing is CPU/RAM-heavy.
+- Do not treat a public demo endpoint as production evidence.

--- a/infra/titiler/cloud-run.service.yaml.example
+++ b/infra/titiler/cloud-run.service.yaml.example
@@ -1,0 +1,33 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: aerial-titiler
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+        autoscaling.knative.dev/maxScale: "10"
+        run.googleapis.com/cpu-throttling: "false"
+    spec:
+      containerConcurrency: 40
+      timeoutSeconds: 60
+      containers:
+        - image: REGION-docker.pkg.dev/PROJECT/aerial/titiler:TAG
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: HOST
+              value: "0.0.0.0"
+            - name: MOSAIC_ENDPOINT_ENABLED
+              value: "FALSE"
+            - name: CORS_ORIGINS
+              value: "https://APP_ORIGIN,https://PREVIEW_ORIGIN"
+          resources:
+            limits:
+              cpu: "2"
+              memory: "2Gi"

--- a/infra/titiler/docker-compose.yml
+++ b/infra/titiler/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  titiler:
+    build:
+      context: .
+      args:
+        TITILER_IMAGE: ${TITILER_IMAGE:-ghcr.io/developmentseed/titiler:latest}
+    ports:
+      - "${TITILER_PORT:-8080}:8080"
+    environment:
+      PORT: "8080"
+      HOST: "0.0.0.0"
+      MOSAIC_ENDPOINT_ENABLED: "FALSE"
+      CORS_ORIGINS: ${TITILER_CORS_ORIGINS:-http://localhost:3000,http://localhost:3001}

--- a/scripts/check_release_readiness.sh
+++ b/scripts/check_release_readiness.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${AERIAL_RELEASE_TARGET:-preview}"
+FAILURES=0
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "missing: ${name}" >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "ok: ${name}"
+  fi
+}
+
+require_env NEXT_PUBLIC_SUPABASE_URL
+require_env NEXT_PUBLIC_SUPABASE_ANON_KEY
+require_env SUPABASE_SERVICE_ROLE_KEY
+require_env AERIAL_TITILER_URL
+
+if [[ "${AERIAL_COPILOT_ENABLED:-false}" == "true" ]]; then
+  if [[ -z "${AI_GATEWAY_API_KEY:-}" && -z "${VERCEL_OIDC_TOKEN:-}" ]]; then
+    echo "missing: AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN while AERIAL_COPILOT_ENABLED=true" >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "ok: AI gateway credential present"
+  fi
+fi
+
+if [[ "$TARGET" == "production" ]]; then
+  if [[ "${AERIAL_TITILER_URL:-}" == *"titiler.xyz"* ]]; then
+    echo "production cannot use public demo TiTiler endpoint: ${AERIAL_TITILER_URL}" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+  if [[ "${AERIAL_TITILER_URL:-}" == http://localhost* ]]; then
+    echo "production cannot use localhost TiTiler endpoint: ${AERIAL_TITILER_URL}" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "release readiness failed: ${FAILURES} issue(s)" >&2
+  exit 1
+fi
+
+echo "release readiness ok for target=${TARGET}"

--- a/scripts/smoke_titiler.sh
+++ b/scripts/smoke_titiler.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TITILER_URL="${AERIAL_TITILER_URL:-}"
+COG_URL="${1:-https://raw.githubusercontent.com/cogeotiff/rio-tiler/master/tests/fixtures/cog.tif}"
+
+if [[ -z "$TITILER_URL" ]]; then
+  echo "AERIAL_TITILER_URL is required." >&2
+  exit 2
+fi
+
+TITILER_URL="${TITILER_URL%/}"
+ENCODED_COG_URL="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$COG_URL")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TILEJSON_PATH="$TMP_DIR/tilejson.json"
+TILE_PATH="$TMP_DIR/tile.png"
+
+curl -fsS \
+  "${TITILER_URL}/cog/WebMercatorQuad/tilejson.json?url=${ENCODED_COG_URL}" \
+  -o "$TILEJSON_PATH"
+
+node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (!Array.isArray(data.bounds) || data.bounds.length !== 4) {
+  throw new Error("tilejson bounds missing");
+}
+if (!Array.isArray(data.tiles) || data.tiles.length === 0) {
+  throw new Error("tilejson tiles missing");
+}
+console.log(`tilejson bounds=${data.bounds.join(",")}`);
+' "$TILEJSON_PATH"
+
+CONTENT_TYPE="$(curl -fsS \
+  -w "%{content_type}" \
+  "${TITILER_URL}/cog/tiles/WebMercatorQuad/2/1/1.png?url=${ENCODED_COG_URL}" \
+  -o "$TILE_PATH")"
+
+if [[ "$CONTENT_TYPE" != image/png* ]]; then
+  echo "Expected image/png tile, got: ${CONTENT_TYPE}" >&2
+  exit 1
+fi
+
+BYTES="$(wc -c < "$TILE_PATH" | tr -d ' ')"
+if [[ "$BYTES" -le 0 ]]; then
+  echo "Tile response was empty." >&2
+  exit 1
+fi
+
+echo "titiler smoke ok: ${TITILER_URL} tile_bytes=${BYTES}"

--- a/web/tests/e2e/README.md
+++ b/web/tests/e2e/README.md
@@ -63,6 +63,11 @@ AERIAL_E2E_SKIP_SERVER=1 \
 
 ## CI posture
 
-Per the plan, E2E should run on non-PR `main` pushes only — PR CI stays fast
-with lint + vitest + build. Add the E2E step behind a branch gate when you
-wire it up.
+Per the plan, unauthenticated public E2E runs on non-PR `main` pushes only —
+PR CI stays fast with lint + vitest + build.
+
+The authenticated operational smoke is wired as a separate `web-auth-smoke`
+job and remains disabled unless the repository variable
+`AERIAL_E2E_AUTH_SMOKE_ENABLED=1` is set. Configure the dedicated Supabase
+project variables and secrets in `docs/ops/test-supabase-project.md` before
+enabling it.


### PR DESCRIPTION
## Summary

- Adds controlled TiTiler service artifacts under `infra/titiler/`, including Docker Compose and a Cloud Run service example.
- Adds executable release gates: `scripts/smoke_titiler.sh` and `scripts/check_release_readiness.sh`.
- Documents production promotion in `docs/RELEASE_CHECKLIST.md`, controlled raster setup, and a dedicated Supabase E2E project setup.
- Adds an optional main-branch `web-auth-smoke` CI job gated by `AERIAL_E2E_AUTH_SMOKE_ENABLED=1`, so authenticated smoke can run only after dedicated test fixtures are provisioned.

## Truth Boundary

This does not claim the Nat Ford TiTiler service is deployed. The current environment has Docker and Supabase CLI, but no Fly/GCloud/AWS CLI credentials. The branch makes the next external deployment step executable and keeps production from accidentally using `https://titiler.xyz`.

## Validation

- `bash -n scripts/smoke_titiler.sh scripts/check_release_readiness.sh`
- `docker compose -f infra/titiler/docker-compose.yml config`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service AERIAL_TITILER_URL=https://titiler.example.com AERIAL_RELEASE_TARGET=production scripts/check_release_readiness.sh`
- Same readiness command with `AERIAL_TITILER_URL=https://titiler.xyz` and `AERIAL_RELEASE_TARGET=production` fails as expected
- `AERIAL_TITILER_URL=https://titiler.xyz scripts/smoke_titiler.sh` passed as script validation only against the public demo endpoint
- `npm ci`
- `npm run lint -- --quiet`
- `npm run test` - 65 files / 414 tests
- `npm run build`
- `npm run test:e2e` - 2 public tests passed / 1 authenticated smoke skipped