### PR TITLE
[codex] add TiTiler Cloud Run deploy workflow

### DIFF
--- a/.github/workflows/deploy-titiler-cloud-run.yml
+++ b/.github/workflows/deploy-titiler-cloud-run.yml
@@ -1,0 +1,74 @@
+name: Deploy TiTiler Cloud Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Optional image tag. Defaults to the short commit SHA."
+        required: false
+        type: string
+      smoke_cog_url:
+        description: "Optional COG URL for post-deploy smoke."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: deploy-controlled-titiler
+    runs-on: ubuntu-latest
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_ARTIFACT_REPOSITORY }}
+      GCP_CLOUD_RUN_SERVICE: ${{ vars.GCP_CLOUD_RUN_SERVICE }}
+      TITILER_CORS_ORIGINS: ${{ vars.TITILER_CORS_ORIGINS }}
+      TITILER_BASE_IMAGE: ${{ vars.TITILER_BASE_IMAGE || 'ghcr.io/developmentseed/titiler:latest' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve image tag
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.image_tag }}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_SHA::12}"
+          fi
+          echo "TITILER_IMAGE_TAG=$tag" >> "$GITHUB_ENV"
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Deploy TiTiler to Cloud Run
+        id: deploy
+        run: scripts/deploy_titiler_cloud_run.sh
+
+      - name: Smoke deployed TiTiler
+        env:
+          AERIAL_TITILER_URL: ${{ steps.deploy.outputs.service_url }}
+          SMOKE_COG_URL: ${{ inputs.smoke_cog_url }}
+        run: |
+          set -euo pipefail
+          if [ -n "$SMOKE_COG_URL" ]; then
+            scripts/smoke_titiler.sh "$SMOKE_COG_URL"
+          else
+            scripts/smoke_titiler.sh
+          fi
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "## Controlled TiTiler deployment"
+            echo ""
+            echo "- Image: \`${{ steps.deploy.outputs.image_uri }}\`"
+            echo "- Service URL: ${{ steps.deploy.outputs.service_url }}"
+            echo ""
+            echo "Next: set Vercel \`AERIAL_TITILER_URL\` to the service URL for Preview and production, then run the authenticated raster smoke."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/2026-04-20-production-readiness-gates.md
+++ b/docs/ops/2026-04-20-production-readiness-gates.md
@@ -7,7 +7,11 @@ repo artifacts.
 ## What shipped
 
 - Controlled TiTiler service artifacts in `infra/titiler/`.
+- Manual Cloud Run deployment workflow for TiTiler in
+  `.github/workflows/deploy-titiler-cloud-run.yml`.
 - `scripts/smoke_titiler.sh` for tilejson and PNG tile smoke checks.
+- `scripts/deploy_titiler_cloud_run.sh` for local or workflow-backed Cloud Run
+  deploys.
 - `scripts/check_release_readiness.sh` for required env and production TiTiler
   guardrails.
 - `docs/RELEASE_CHECKLIST.md` for production promotion.
@@ -20,6 +24,7 @@ repo artifacts.
 From the repository root:
 
 - `bash -n scripts/smoke_titiler.sh scripts/check_release_readiness.sh` - pass.
+- `bash -n scripts/deploy_titiler_cloud_run.sh` - pass.
 - `docker compose -f infra/titiler/docker-compose.yml config` - pass.
 - `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service AERIAL_TITILER_URL=https://titiler.example.com AERIAL_RELEASE_TARGET=production scripts/check_release_readiness.sh` - pass.
 - Same readiness command with `AERIAL_TITILER_URL=https://titiler.xyz` and `AERIAL_RELEASE_TARGET=production` - fails as expected.

--- a/docs/ops/titiler-setup.md
+++ b/docs/ops/titiler-setup.md
@@ -96,6 +96,9 @@ The deployable service shape now lives in `infra/titiler/`:
 - `docker-compose.yml` runs the same shape locally.
 - `cloud-run.service.yaml.example` captures the Cloud Run container settings,
   resource floor, and CORS envs to fill for a Nat Ford deployment.
+- `.github/workflows/deploy-titiler-cloud-run.yml` is a manual workflow that
+  builds, pushes, deploys, and smokes the controlled Cloud Run service after the
+  required GCP repository variables and Workload Identity secrets are set.
 
 Smoke any controlled endpoint before wiring the app to it:
 

--- a/infra/titiler/README.md
+++ b/infra/titiler/README.md
@@ -29,6 +29,30 @@ AERIAL_TITILER_URL=http://localhost:8080 ../../scripts/smoke_titiler.sh
 project id, region, artifact registry path, and CORS origins are environment
 specific.
 
+The preferred deployment path is the manual GitHub Actions workflow:
+
+```text
+Deploy TiTiler Cloud Run
+```
+
+Configure repository variables:
+
+- `GCP_PROJECT_ID`
+- `GCP_REGION`
+- `GCP_ARTIFACT_REPOSITORY`
+- `GCP_CLOUD_RUN_SERVICE`
+- `TITILER_CORS_ORIGINS`
+- `TITILER_BASE_IMAGE` (optional; defaults to `ghcr.io/developmentseed/titiler:latest`)
+
+Configure repository secrets for Workload Identity Federation:
+
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `GCP_SERVICE_ACCOUNT`
+
+The workflow builds `infra/titiler`, pushes the image to Artifact Registry,
+deploys Cloud Run, and runs `scripts/smoke_titiler.sh` against the deployed
+service URL.
+
 Minimal deployment flow:
 
 ```bash
@@ -50,6 +74,17 @@ gcloud run services add-iam-policy-binding aerial-titiler \
 
 Run `scripts/smoke_titiler.sh` against the Cloud Run URL before setting
 `AERIAL_TITILER_URL` in Vercel.
+
+Local equivalent after `gcloud auth login`:
+
+```bash
+GCP_PROJECT_ID=PROJECT \
+GCP_REGION=REGION \
+GCP_ARTIFACT_REPOSITORY=aerial \
+GCP_CLOUD_RUN_SERVICE=aerial-titiler \
+TITILER_CORS_ORIGINS='https://APP_ORIGIN,https://PREVIEW_ORIGIN' \
+  scripts/deploy_titiler_cloud_run.sh
+```
 
 ## Production requirements
 

--- a/scripts/deploy_titiler_cloud_run.sh
+++ b/scripts/deploy_titiler_cloud_run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "${name} is required." >&2
+    exit 2
+  fi
+}
+
+require_env GCP_PROJECT_ID
+require_env GCP_REGION
+require_env GCP_ARTIFACT_REPOSITORY
+require_env GCP_CLOUD_RUN_SERVICE
+require_env TITILER_CORS_ORIGINS
+
+TITILER_IMAGE_TAG="${TITILER_IMAGE_TAG:-$(git rev-parse --short HEAD)}"
+TITILER_BASE_IMAGE="${TITILER_BASE_IMAGE:-ghcr.io/developmentseed/titiler:latest}"
+REGISTRY_HOST="${GCP_REGION}-docker.pkg.dev"
+IMAGE_URI="${REGISTRY_HOST}/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/aerial-titiler:${TITILER_IMAGE_TAG}"
+
+gcloud config set project "$GCP_PROJECT_ID" >/dev/null
+gcloud auth configure-docker "$REGISTRY_HOST" --quiet
+
+docker build \
+  --build-arg "TITILER_IMAGE=${TITILER_BASE_IMAGE}" \
+  -t "$IMAGE_URI" \
+  infra/titiler
+docker push "$IMAGE_URI"
+
+gcloud run deploy "$GCP_CLOUD_RUN_SERVICE" \
+  --image "$IMAGE_URI" \
+  --region "$GCP_REGION" \
+  --platform managed \
+  --allow-unauthenticated \
+  --port 8080 \
+  --cpu 2 \
+  --memory 2Gi \
+  --concurrency 40 \
+  --timeout 60s \
+  --set-env-vars "^|^PORT=8080|HOST=0.0.0.0|MOSAIC_ENDPOINT_ENABLED=FALSE|CORS_ORIGINS=${TITILER_CORS_ORIGINS}"
+
+SERVICE_URL="$(gcloud run services describe "$GCP_CLOUD_RUN_SERVICE" \
+  --region "$GCP_REGION" \
+  --format 'value(status.url)')"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "image_uri=${IMAGE_URI}"
+    echo "service_url=${SERVICE_URL}"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+echo "deployed image=${IMAGE_URI}"
+echo "service_url=${SERVICE_URL}"


### PR DESCRIPTION
## Summary

- Adds a manual GitHub Actions workflow, `Deploy TiTiler Cloud Run`, for the controlled raster service.
- Adds `scripts/deploy_titiler_cloud_run.sh` to build `infra/titiler`, push to Artifact Registry, deploy Cloud Run, and expose the deployed service URL.
- Updates the TiTiler docs and production-readiness evidence with required GCP variables/secrets and deployment flow.
- Comments on issue #60 with the required repository configuration.

## Truth Boundary

This still does not deploy the external TiTiler service from this session because no GCP/Fly/AWS credentials are available. Once the GCP Workload Identity secrets and repository variables are configured, the manual workflow can perform the deployment and post-deploy smoke.

## Validation

- `bash -n scripts/deploy_titiler_cloud_run.sh scripts/smoke_titiler.sh scripts/check_release_readiness.sh`
- `docker compose -f infra/titiler/docker-compose.yml config`
- workflow files are readable and include `runs-on`
- `git diff --check`
- `npm ci`
- `npm run lint -- --quiet`
- `npm run test` - 65 files / 414 tests
- `npm run build`